### PR TITLE
Feature/31/implement commnad privmsg

### DIFF
--- a/include/Commands/Send_messages/Privmsg_cmd.hpp
+++ b/include/Commands/Send_messages/Privmsg_cmd.hpp
@@ -18,7 +18,7 @@
 
 사용자 간 개인 메시지를 보내는 데 사용
 
-receiver는 쉼표로 구분 된 닉네임이나 채널 이름
+receiver는 쉼표로 구분 된 닉네임이나 채널 이름 (only comma, no space)
 
 서버/호스트 마스크일 수도 있음(운영자만 사용 가능)
 
@@ -36,16 +36,53 @@ receiver는 쉼표로 구분 된 닉네임이나 채널 이름
 
 class Privmsg_cmd : public Command
 {
+private:
+    std::list<std::string> _receiver;
+    std::string _message;
+    bool _wildcard;
+
+    bool    check_wildcard_validity()
+    {
+        for (str_list_iter it = _receiver.begin(); it != _receiver.end(); it++)
+        {
+            if (*(*it).begin() == '#' || *(*it).begin() == '?')
+            {
+                if ((*it).find_last_of('.') != std::string::npos)
+                {
+                    // check wildcard exist
+                }
+                else
+                    return false;
+            }
+            else
+            {
+                // if wildcard exist false;
+            }
+        }
+    }
 public:
     Privmsg_cmd() : Command("PRIVMSG")
     {
+        _message = "";
+        _wildcard = false;
     }
 
     virtual void parse_args(str_list args)
     {
-        std::cout << "args : ";
-
-        (void)args;
+        str_list_iter   it = args.begin();
+        // args 수가 모자란 경우
+        if (args.size() < 2)
+        {
+            return ;
+        }
+        _receiver = split((*it), ',');
+        _message = (*(++it));
+        // wildcard 존재여부 확인 (wildcard는 operator 권한이 있어야 사용가능)
+        for (str_list_iter it_rec; it_rec != _receiver.end(); it_rec++)
+        {
+            if (((*it_rec).find('?') != std::string::npos) || (*it_rec).find('*') != std::string::npos)
+                _wildcard = true;
+        }
     }
 
     virtual void execute(Server* server, Client* client)

--- a/include/Commands/Send_messages/Privmsg_cmd.hpp
+++ b/include/Commands/Send_messages/Privmsg_cmd.hpp
@@ -41,8 +41,19 @@ private:
     std::string _message;
     bool _wildcard;
 
-    bool    check_wildcard_validity()
+    bool is_wildcard_exist(std::string str)
     {
+        if (str.find('?') != std::string::npos)
+            return true;
+        if (str.find('*') != std::string::npos)
+            return true;
+        return false;
+    }
+
+    bool check_wildcard_validity()
+    {
+        bool ret = true;
+
         for (str_list_iter it = _receiver.begin(); it != _receiver.end(); it++)
         {
             if (*(*it).begin() == '#' || *(*it).begin() == '?')
@@ -50,15 +61,20 @@ private:
                 if ((*it).find_last_of('.') != std::string::npos)
                 {
                     // check wildcard exist
+                    size_t pos = (*it).find_last_of('.');
+                    std::string substr = (*it).substr(pos + 1);
+                    ret &= !is_wildcard_exist(substr);
                 }
                 else
-                    return false;
+                    ret &= false;
             }
             else
             {
                 // if wildcard exist false;
+                ret &= !is_wildcard_exist(*it);
             }
         }
+        return (ret);
     }
 public:
     Privmsg_cmd() : Command("PRIVMSG")

--- a/include/Commands/Send_messages/Privmsg_cmd.hpp
+++ b/include/Commands/Send_messages/Privmsg_cmd.hpp
@@ -105,9 +105,25 @@ public:
 
     virtual void execute(Server* server, Client* client)
     {
-        (void)server;
-        (void)client;
         std::cout << "Execute PRIVMSG" << std::endl;
+        if (_wildcard && 0) // 1 << client.is_oper()
+            return ;  // no permission err msg
+        
+        for (str_list_iter it = _receiver.begin(); it != _receiver.end(); it++)
+        {
+            if (*(*it).begin() == '#' || *(*it).begin() == '?')
+            {
+                ; //server or host
+            }
+            else
+            {
+                Client *dest = server->get_client_by_nickname(*it);
+                if (!dest)
+                    return ; // no such client
+                std::string prefix = ":" + dest->get_nickname() + "@" + server->get_host();
+                dest->message_client(prefix + " PRIVMSG " + (*it) + "_message");
+            }
+        }
         init_cmd();
     }
 

--- a/include/Commands/Send_messages/Privmsg_cmd.hpp
+++ b/include/Commands/Send_messages/Privmsg_cmd.hpp
@@ -99,6 +99,8 @@ public:
             if (((*it_rec).find('?') != std::string::npos) || (*it_rec).find('*') != std::string::npos)
                 _wildcard = true;
         }
+        if (_wildcard && !check_wildcard_validity())
+            return ;   // wildcard 예외 메시지
     }
 
     virtual void execute(Server* server, Client* client)
@@ -111,6 +113,9 @@ public:
 
     virtual void init_cmd()
     {
+        _message = "";
+        _wildcard = false;
+        _receiver.clear();
         std::cout << "Init command" << std::endl;
     }
 

--- a/include/Server.hpp
+++ b/include/Server.hpp
@@ -47,6 +47,7 @@ public:
     // 클라이언트 관련 함수
     std::list<Client *> get_clients();
     Client *get_client_by_socket_fd(int socket_fd);
+    Client *get_client_by_nickname(std::string nickname);
     void delete_client(int socket_fd);
 
     // 채널 관련 함수

--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -255,6 +255,18 @@ Client* Server::get_client_by_socket_fd(int socket_fd)
 	return (NULL);
 }
 
+Client* Server::get_client_by_nickname(std::string nickname)
+{
+	std::list<Client *>::iterator it = _clients.begin();
+	while ((it != _clients.end()))
+	{
+		if ((*it)->get_nickname() == nickname)
+			return (*it);
+		it++;
+	}
+	return (NULL);
+}
+
 
 /** 채널 관련 함수 **/
 void Server::add_channel(std::string name, Client* client)


### PR DESCRIPTION
Server
- Client를 nickname으로 찾는 함수 추가

PRIVMSG
- wildcard 포함시 감지
- server/channel과 일반 nickname 구분
- 일반 nickname 대상으로 privmsg 구현

추가 구현 필요
- wildcard시 client가 op 권한이 존재하는지 확인하는 함수
- server나 channel을 대상으로 하는 privmsg
- client의 prefix 메시지를 리턴하는 함수를 client.cpp에 구현하는 것이 좋아보임