### PR TITLE
Add: init_cmd() when command error

### DIFF
--- a/src/Server.cpp
+++ b/src/Server.cpp
@@ -147,6 +147,7 @@ int Server::recv_message(int cur_fd)
 				catch (const std::exception& e)
 				{
 					serverResponse(e.what(), cur_fd);
+					_cmd->init_cmd();
 				}
 				
 				break;


### PR DESCRIPTION
try-catch의 catch문의 _cmd->init_cmd() 호출해서 커맨드 초기화